### PR TITLE
Add install-remote.sh to all camps

### DIFF
--- a/camps/9c-backoffice/install-remote.sh
+++ b/camps/9c-backoffice/install-remote.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+# Remote installer for 9c-backoffice skill (run on OpenClaw or any agent workspace)
+# Usage: curl -sL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/9c-backoffice/install-remote.sh | bash
+set -euo pipefail
+
+BASE="https://raw.githubusercontent.com/planetarium/CampForge/main"
+WS="${WORKSPACE:-workspace}"
+
+# gql-ops (dependency)
+mkdir -p "$WS/skills/gql-ops"
+curl -sL "$BASE/packages/gql-ops/skills/gql-ops/SKILL.md" -o "$WS/skills/gql-ops/SKILL.md"
+
+# 9c-backoffice
+mkdir -p "$WS/skills/9c-backoffice/queries" "$WS/skills/9c-backoffice/references"
+curl -sL "$BASE/camps/9c-backoffice/skills/9c-backoffice/SKILL.md" -o "$WS/skills/9c-backoffice/SKILL.md"
+curl -sL "$BASE/camps/9c-backoffice/skills/9c-backoffice/references/api-endpoints.md" -o "$WS/skills/9c-backoffice/references/api-endpoints.md"
+for f in check-deleted-addresses sheet-compare sheet-list table-patch-purge-cache table-patch-sign table-patch-stage table-patch-tx-result table-patch-upload-r2 table-patch-validate; do
+  curl -sL "$BASE/camps/9c-backoffice/skills/9c-backoffice/queries/${f}.gql" -o "$WS/skills/9c-backoffice/queries/${f}.gql"
+done
+
+echo "9c-backoffice skill installed (with gql-ops dependency)"

--- a/camps/campforge-guide/install-remote.sh
+++ b/camps/campforge-guide/install-remote.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Remote installer for campforge-guide skills (run on OpenClaw or any agent workspace)
+# Usage: curl -sL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/campforge-guide/install-remote.sh | bash
+set -euo pipefail
+
+BASE="https://raw.githubusercontent.com/planetarium/CampForge/main"
+WS="${WORKSPACE:-workspace}"
+
+# gql-ops (dependency)
+mkdir -p "$WS/skills/gql-ops"
+curl -sL "$BASE/packages/gql-ops/skills/gql-ops/SKILL.md" -o "$WS/skills/gql-ops/SKILL.md"
+
+# campforge-guide skills
+for skill in camp-add-skill camp-bench camp-create camp-sync camp-validate; do
+  mkdir -p "$WS/skills/${skill}"
+  curl -sL "$BASE/camps/campforge-guide/skills/${skill}/SKILL.md" -o "$WS/skills/${skill}/SKILL.md"
+done
+
+echo "campforge-guide skills installed (with gql-ops dependency)"

--- a/camps/campforge-guide/skills/camp-create/SKILL.md
+++ b/camps/campforge-guide/skills/camp-create/SKILL.md
@@ -112,12 +112,35 @@ mv $CAMPFORGE_CLI/campforge-{domain-id} <campforge-project>/camps/
 
 `camp-validate` 스킬을 사용하여 생성 결과를 검증한다.
 
-### Step 7: 설치 안내
+### Step 7: install-remote.sh 생성
+
+원격 에이전트(예: OpenClaw on Docker)에서 curl 한 줄로 스킬을 설치할 수 있도록 `install-remote.sh`를 생성한다.
+
+```bash
+#!/usr/bin/env bash
+# Remote installer for <camp-name> skill (run on OpenClaw or any agent workspace)
+# Usage: curl -sL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/<camp-name>/install-remote.sh | bash
+set -euo pipefail
+
+BASE="https://raw.githubusercontent.com/planetarium/CampForge/main"
+WS="${WORKSPACE:-workspace}"
+
+# 의존성 설치 (gql-ops 등)
+# 각 스킬의 SKILL.md 및 하위 파일(queries/, references/ 등) 설치
+```
+
+v8-admin의 `install-remote.sh`를 참고하여 해당 캠프의 스킬 파일 구조에 맞게 작성한다.
+
+### Step 8: 설치 안내
 
 검증 통과 후, 생성된 캠프를 에이전트에 설치하는 방법을 안내한다:
 
 ```bash
+# 로컬 설치
 cd <camp-directory> && ./campforge-cli.sh
+
+# 원격 설치 (OpenClaw 등)
+curl -sL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/<camp-name>/install-remote.sh | bash
 ```
 
 이 스크립트가 현재 환경을 감지하여 적절한 어댑터(Claude Code, OpenClaw 등)를 자동 실행한다.

--- a/camps/campforge-guide/skills/camp-validate/SKILL.md
+++ b/camps/campforge-guide/skills/camp-validate/SKILL.md
@@ -32,7 +32,7 @@ cd $CAMPFORGE_CLI && ./node_modules/.bin/tsx bin/campforge.ts validate <camp-dir
 
 ### Step 2: 결과 해석
 
-검증 항목 (총 8가지):
+검증 항목 (총 9가지):
 
 | # | 검증 항목 | 흔한 실패 원인 |
 |---|-----------|---------------|
@@ -44,6 +44,7 @@ cd $CAMPFORGE_CLI && ./node_modules/.bin/tsx bin/campforge.ts validate <camp-dir
 | 6 | 어댑터 install.sh 존재 | adapters/ 디렉토리가 비어있음 |
 | 7 | package.json (의존성 선언 시) | skill 의존성이 있는데 package.json 없음 |
 | 8 | campforge-cli.sh 존재 | 파일 누락 |
+| 9 | install-remote.sh 존재 | 원격 설치 스크립트 누락 |
 
 ### Step 3: 오류 수정 안내
 

--- a/camps/iap-manager/install-remote.sh
+++ b/camps/iap-manager/install-remote.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+# Remote installer for iap-manager skills (run on OpenClaw or any agent workspace)
+# Usage: curl -sL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/iap-manager/install-remote.sh | bash
+set -euo pipefail
+
+BASE="https://raw.githubusercontent.com/planetarium/CampForge/main"
+WS="${WORKSPACE:-workspace}"
+
+# gql-ops (dependency)
+mkdir -p "$WS/skills/gql-ops"
+curl -sL "$BASE/packages/gql-ops/skills/gql-ops/SKILL.md" -o "$WS/skills/gql-ops/SKILL.md"
+
+# iap-manager skills
+for skill in iap-asset-import iap-image-upload iap-product-import iap-product-query iap-receipt-query; do
+  mkdir -p "$WS/skills/${skill}"
+  curl -sL "$BASE/camps/iap-manager/skills/${skill}/SKILL.md" -o "$WS/skills/${skill}/SKILL.md"
+done
+
+echo "iap-manager skills installed (with gql-ops dependency)"


### PR DESCRIPTION
## Summary
- Add `install-remote.sh` to `9c-backoffice`, `iap-manager`, `campforge-guide` camps
- Update `camp-create` SKILL.md with install-remote.sh generation step (Step 7)
- Update `camp-validate` SKILL.md with install-remote.sh presence check (item #9)

Closes #2

## Test plan
- [ ] Verify each `install-remote.sh` curls the correct files for its camp
- [ ] Confirm `camp-validate` checks for `install-remote.sh` presence
- [ ] Confirm `camp-create` workflow includes install-remote.sh generation step

🤖 Generated with [Claude Code](https://claude.com/claude-code)