### PR TITLE
fix: add missing gws-auth tarball dependency to v8-admin installer

### DIFF
--- a/camps/v8-admin/install.sh
+++ b/camps/v8-admin/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/v8-admin/install.sh | bash
 set -euo pipefail
 
-CAMP_VERSION="${CAMP_VERSION:-v1.1.0}"
+CAMP_VERSION="${CAMP_VERSION:-v1.2.0}"
 BASE="https://github.com/planetarium/CampForge/releases/download/v8-admin-${CAMP_VERSION}"
 
 WS="${WORKSPACE:-workspace}"
@@ -13,6 +13,7 @@ npm init -y --silent 2>/dev/null
 npm pkg set \
   "dependencies.@campforge/v8-api=$BASE/campforge-v8-api-1.0.0.tgz" \
   "dependencies.@campforge/gql-ops=$BASE/campforge-gql-ops-0.2.0.tgz" \
+  "dependencies.@campforge/gws-auth=$BASE/campforge-gws-auth-0.1.0.tgz" \
   "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.0.tgz"
 
 npx skillpm install

--- a/camps/v8-admin/package.json
+++ b/camps/v8-admin/package.json
@@ -7,6 +7,7 @@
   "dependencies": {
     "@campforge/v8-api": "^1.0.0",
     "@campforge/gql-ops": "^0.2.0",
+    "@campforge/gws-auth": "^0.1.0",
     "@campforge/gws-sheets": "^0.1.0"
   }
 }


### PR DESCRIPTION
## Summary
- `@campforge/gws-sheets`가 `@campforge/gws-auth`를 npm 의존성으로 선언하지만, v8-admin installer가 이 tarball을 포함하지 않아 `npm install` 시 public registry에서 404 발생
- `camps/v8-admin/package.json`과 `install.sh`에 `@campforge/gws-auth` tarball 의존성 추가
- `CAMP_VERSION`을 v1.2.0으로 범프

Closes #18

## Test plan
- [ ] 머지 후 `v8-admin-v1.2.0` 태그 푸시 → CI가 `gws-auth` tarball 포함한 릴리스 자동 생성 확인
- [ ] 릴리스 생성 후 `curl -fsSL ... | bash` 인스톨러가 정상 완료되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)