### PR TITLE
feat: switch v8-admin default endpoints to production

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Each camp requires specific environment variables. The agent will ask for them o
 
 **v8-admin:**
 ```bash
-export V8_GQL="https://planetarium-oag.fly.dev/v8-admin-test/graphql"
+export V8_GQL="https://planetarium-oag.fly.dev/v8-admin/graphql"
 export V8_TOKEN="<your JWT>"
 export V8_SKILL_DIR="<path to v8-api skill directory>"  # for --queryFile paths
 ```

--- a/packages/v8-api/skills/v8-api/SKILL.md
+++ b/packages/v8-api/skills/v8-api/SKILL.md
@@ -19,7 +19,7 @@ compatibility: Requires gq (graphqurl) CLI and a running GraphQL gateway
 ## Environment variables
 
 ```bash
-echo $V8_GQL        # GraphQL gateway URL (default: https://planetarium-oag.fly.dev/v8-admin-test/graphql)
+echo $V8_GQL        # GraphQL gateway URL (default: https://planetarium-oag.fly.dev/v8-admin/graphql)
 echo $V8_SKILL_DIR   # Absolute path to this skill directory
 ```
 

--- a/packages/v8-api/skills/v8-api/references/admin-api.md
+++ b/packages/v8-api/skills/v8-api/references/admin-api.md
@@ -3,9 +3,9 @@
 Auth: `Authorization: Bearer <token>` (JWT)
 
 Environments:
+- Production: `https://v8-meme-api.verse8.io`
 - Test: `https://v8api.tests.mothership-pla.net`
 - Local dev: `https://<ngrok-url>` (changes per session)
-- Production: not yet supported
 
 ---
 

--- a/packages/v8-api/skills/v8-api/v8-auth.sh
+++ b/packages/v8-api/skills/v8-api/v8-auth.sh
@@ -6,7 +6,7 @@
 #   bash v8-auth.sh logout           # clear stored token
 set -euo pipefail
 
-V8_API="${V8_API_BASE:-https://v8api.tests.mothership-pla.net}"
+V8_API="${V8_API_BASE:-https://v8-meme-api.verse8.io}"
 TOKEN_FILE="${V8_TOKEN_FILE:-${HOME}/.config/v8/token}"
 
 # --- helpers ---


### PR DESCRIPTION
## Summary
- GQL 기본 URL을 `v8-admin-test` → `v8-admin`으로 변경
- REST API / 인증 기본 URL을 `v8api.tests.mothership-pla.net` → `v8-meme-api.verse8.io`로 변경
- 테스트 환경은 `V8_GQL`, `V8_API_BASE` 환경변수 오버라이드로 계속 사용 가능

## Test plan
- [ ] 프로덕션 GQL 엔드포인트 (`planetarium-oag.fly.dev/v8-admin/graphql`) 접근 확인
- [ ] 프로덕션 REST API (`v8-meme-api.verse8.io`) device auth flow 정상 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)