### PR TITLE
chore: bump v8-api to 1.1.0 for v8-admin-v1.2.0 release

### DIFF
--- a/camps/v8-admin/install.sh
+++ b/camps/v8-admin/install.sh
@@ -11,7 +11,7 @@ mkdir -p "$WS" && cd "$WS"
 
 npm init -y --silent 2>/dev/null
 npm pkg set \
-  "dependencies.@campforge/v8-api=$BASE/campforge-v8-api-1.0.0.tgz" \
+  "dependencies.@campforge/v8-api=$BASE/campforge-v8-api-1.1.0.tgz" \
   "dependencies.@campforge/gql-ops=$BASE/campforge-gql-ops-0.2.0.tgz" \
   "dependencies.@campforge/gws-auth=$BASE/campforge-gws-auth-0.1.0.tgz" \
   "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.0.tgz"

--- a/packages/v8-api/package.json
+++ b/packages/v8-api/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@campforge/v8-api",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "V8 platform API skill — users, credits, verses, comments, game payments",
   "keywords": ["agent-skill", "v8", "api", "campforge"],
   "license": "Apache-2.0",


### PR DESCRIPTION
## Summary
- `@campforge/v8-api` 버전 1.0.0 → 1.1.0 범프
- `install.sh` tarball 파일명 업데이트

머지 후 `v8-admin-v1.2.0` 태그 푸시하면 CI가 릴리스 자동 생성합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)