### PR TITLE
feat: add Playwriter as camp-level dependency for flex-ax

### DIFF
--- a/camps/flex-ax/install.sh
+++ b/camps/flex-ax/install.sh
@@ -37,6 +37,7 @@ fi
 install_flex_ax
 install_gws
 install_gws_auth
+install_playwriter
 install_camp_files "$BASE/camp-flex-ax.tgz"
 generate_adapters
 

--- a/camps/flex-ax/knowledge/playwriter-setup.md
+++ b/camps/flex-ax/knowledge/playwriter-setup.md
@@ -39,12 +39,16 @@ A successful response returns JSON with Chrome version information, confirming t
 - Use **Git Bash**, **MSYS2**, or **WSL** to run the install script and CLI
   wrappers. The installer generates both `.cmd` (for cmd.exe/PowerShell) and
   extensionless shell wrappers (for Git Bash).
-- **Node 24+** may be required on Windows due to ESM module resolution issues
-  in older Node versions. If you encounter `ERR_MODULE_NOT_FOUND` or similar
-  errors, upgrade Node.
 - Make sure the `.local/bin` directory created by the installer is on your
   PATH. The installer adds it automatically for the current session, but you
   may need to add it to your shell profile for persistence.
+
+> **Node 24+ is REQUIRED on Windows.** Playwriter is a pure ESM package. On Windows
+> with Node versions older than 24, `playwriter serve` will fail with
+> `ERR_REQUIRE_ESM` or `SyntaxError: Cannot use import statement outside a module`.
+> This is an upstream Node/ESM interop limitation that cannot be worked around.
+>
+> Download Node 24+: <https://nodejs.org/>
 - **Use `curl.exe` instead of `curl`**: In PowerShell, `curl` is aliased to `Invoke-WebRequest`. Use `curl.exe` explicitly when verifying the relay.
 
 ## Troubleshooting

--- a/camps/flex-ax/knowledge/playwriter-setup.md
+++ b/camps/flex-ax/knowledge/playwriter-setup.md
@@ -18,6 +18,22 @@ pieces below must be in place before `flex-ax crawl` can succeed.
 4. **Relay reachable** -- flex-ax connects to the Playwriter relay at
    `127.0.0.1:19988`. Ensure no firewall or proxy blocks this port.
 
+## Verifying the Relay
+
+```bash
+curl http://127.0.0.1:19988/json/version
+```
+
+A successful response returns JSON with Chrome version information, confirming the relay is active.
+
+## Full Workflow
+
+1. Start the relay: `playwriter serve --host 127.0.0.1`
+2. Open Chrome and navigate to flex.team.
+3. Log in to flex.team if not already logged in.
+4. Activate the Playwriter Chrome extension on the flex.team tab.
+5. Run the crawl: `flex-ax crawl --auth playwriter`
+
 ## Windows-specific notes
 
 - Use **Git Bash**, **MSYS2**, or **WSL** to run the install script and CLI
@@ -29,3 +45,12 @@ pieces below must be in place before `flex-ax crawl` can succeed.
 - Make sure the `.local/bin` directory created by the installer is on your
   PATH. The installer adds it automatically for the current session, but you
   may need to add it to your shell profile for persistence.
+- **Use `curl.exe` instead of `curl`**: In PowerShell, `curl` is aliased to `Invoke-WebRequest`. Use `curl.exe` explicitly when verifying the relay.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Waiting for MCP WS Server..." | Relay is not running | Start it with `playwriter serve --host 127.0.0.1` |
+| Connection refused on port 19988 | Relay crashed or bound to a different host | Restart the relay; ensure `--host 127.0.0.1` is specified |
+| ESM / import errors on Windows | Node version too old | Upgrade Node to 24+ |

--- a/scripts/install-common.sh
+++ b/scripts/install-common.sh
@@ -245,6 +245,17 @@ install_playwriter() {
 
   path_append "$prefix/bin"
   echo "  playwriter $version installed at $prefix/bin/playwriter"
+
+  # Warn if Node < 24 on Windows (Playwriter has ESM issues on older Node)
+  if is_windows; then
+    local node_major
+    node_major=$(node -v | sed 's/v\([0-9]*\).*/\1/')
+    if [ "$node_major" -lt 24 ] 2>/dev/null; then
+      echo "⚠  playwriter requires Node 24+ on Windows (current: $(node -v))"
+      echo "   Install Node 24+: https://nodejs.org/"
+      echo "   Without it, 'playwriter serve' will fail with ESM errors."
+    fi
+  fi
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/install-common.sh
+++ b/scripts/install-common.sh
@@ -224,6 +224,29 @@ install_gws_auth() {
   echo "  gws-auth installed at $prefix/bin/gws-auth"
 }
 
+# Install Playwriter (CDP relay for cookie extraction from logged-in Chrome).
+install_playwriter() {
+  echo ":: Installing playwriter..."
+  local prefix="$(pwd)/.local"
+  local version="${PLAYWRITER_VERSION:-0.0.105}"
+
+  mkdir -p "$prefix"
+
+  ensure_npm_dir
+  npm install --prefix "$prefix" "playwriter@$version" 2>/dev/null || {
+    echo "  [warn] playwriter install failed."
+    return
+  }
+
+  local cli_js="$prefix/node_modules/playwriter/dist/cli.js"
+  if [ -f "$cli_js" ]; then
+    link_node_bin "$prefix" "playwriter" "$cli_js"
+  fi
+
+  path_append "$prefix/bin"
+  echo "  playwriter $version installed at $prefix/bin/playwriter"
+}
+
 # ---------------------------------------------------------------------------
 # Platform adapter: wire identity/knowledge files into the agent's context.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add `install_playwriter()` to `scripts/install-common.sh` following the same npm-install-and-symlink pattern used by `install_gws` and `install_gws_auth`
- Call `install_playwriter` in `camps/flex-ax/install.sh` alongside the other camp-level dependencies
- Add `camps/flex-ax/knowledge/playwriter-setup.md` covering prerequisites, relay startup, full workflow, Windows notes, and troubleshooting

Fixes #37

## Test plan
- [ ] Run `camps/flex-ax/install.sh` and verify `playwriter` binary is available in `.local/bin/`
- [ ] Confirm `playwriter serve --host 127.0.0.1` starts the CDP relay on port 19988
- [ ] Verify `flex-ax crawl --auth playwriter` works end-to-end with the relay running

🤖 Generated with [Claude Code](https://claude.com/claude-code)