### PR TITLE
fix: bump v8-admin gws-sheets dep to 0.1.1 (fixes #42)

### DIFF
--- a/camps/v8-admin/install.sh
+++ b/camps/v8-admin/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/v8-admin/install.sh | bash
 set -euo pipefail
 
-CAMP_VERSION="${CAMP_VERSION:-v1.2.0}"
+CAMP_VERSION="${CAMP_VERSION:-v1.3.0}"
 BASE="https://github.com/planetarium/CampForge/releases/download/v8-admin-${CAMP_VERSION}"
 
 WS="${WORKSPACE:-workspace}"
@@ -14,7 +14,7 @@ npm pkg set \
   "dependencies.@campforge/v8-api=$BASE/campforge-v8-api-1.1.0.tgz" \
   "dependencies.@campforge/gql-ops=$BASE/campforge-gql-ops-0.2.0.tgz" \
   "dependencies.@campforge/gws-auth=$BASE/campforge-gws-auth-0.1.0.tgz" \
-  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.0.tgz"
+  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.1.tgz"
 
 npx skillpm install
 


### PR DESCRIPTION
## Summary
- The `v8-admin` camp installer referenced `campforge-gws-sheets-0.1.0.tgz`, but `packages/gws-sheets` is at version `0.1.1`. Locally packed tarballs use the source version, so the E2E install test in CI 404'd on every run.
- Bump the dependency URL to `0.1.1` and bump `CAMP_VERSION` to `v1.3.0` ahead of the next release (matching the pattern in 3ba14dc).

The other failing camps in #42 share the same root cause via this single camp; once the v8-admin installer is fixed, the 6 failing test cases should pass. (`9c-backoffice` and `campforge-guide` were already passing in the failing run logs — only v8-admin's install step failed, and the failures were attributed across cases by the test harness.)

## Test plan
- [ ] CI: E2E install test passes for all camps
- [ ] After merge, cut a `v8-admin-v1.3.0` GitHub Release containing `campforge-gws-sheets-0.1.1.tgz` so curl-based installs continue to work

Fixes #42

🤖 Generated with [Claude Code](https://claude.com/claude-code)