### PR TITLE
fix: bump 9c-backoffice and campforge-guide installers to v1.0.2

### DIFF
--- a/camps/9c-backoffice/install.sh
+++ b/camps/9c-backoffice/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/9c-backoffice/install.sh | bash
 set -euo pipefail
 
-CAMP_VERSION="${CAMP_VERSION:-v1.0.1}"
+CAMP_VERSION="${CAMP_VERSION:-v1.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/9c-backoffice-${CAMP_VERSION}"
 
 WS="${WORKSPACE:-workspace}"

--- a/camps/campforge-guide/install.sh
+++ b/camps/campforge-guide/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/campforge-guide/install.sh | bash
 set -euo pipefail
 
-CAMP_VERSION="${CAMP_VERSION:-v1.0.1}"
+CAMP_VERSION="${CAMP_VERSION:-v1.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/campforge-guide-${CAMP_VERSION}"
 
 WS="${WORKSPACE:-workspace}"


### PR DESCRIPTION
## Summary

- Bumps default `CAMP_VERSION` in `camps/9c-backoffice/install.sh` and `camps/campforge-guide/install.sh` from `v1.0.1` to `v1.0.2`.
- Both v1.0.1 releases (cut 2026-04-02) predate #23, which introduced `camp-<name>.tgz` bundling of identity/knowledge files. So current `install.sh` calls `install_camp_files "$BASE/camp-<camp>.tgz"` against a file that was never uploaded — installer dies with 404 at that step.
- Same class of bug as #46 (v8-admin-v1.3.0).

## Rollout

After this PR merges, tag the merge commit:

```
git tag 9c-backoffice-v1.0.2 <sha>
git tag campforge-guide-v1.0.2 <sha>
git push origin 9c-backoffice-v1.0.2 campforge-guide-v1.0.2
```

The `release.yml` workflow will auto-pack and publish the missing `camp-*.tgz` alongside the existing skill tarballs.

## Test plan

- [ ] Merge PR
- [ ] Push tags `9c-backoffice-v1.0.2` and `campforge-guide-v1.0.2` pointing at the merge commit
- [ ] Verify both release workflow runs succeed
- [ ] HEAD-check every asset URL from both `install.sh` files returns 200
- [ ] (Optional) Run `curl -fsSL .../install.sh | bash` for each camp to confirm end-to-end install

🤖 Generated with [Claude Code](https://claude.com/claude-code)