### PR TITLE
ci: add install.sh validation workflows (closes #46)

### DIFF
--- a/.github/workflows/check-install-urls.yml
+++ b/.github/workflows/check-install-urls.yml
@@ -1,0 +1,18 @@
+name: Check install.sh URLs
+
+on:
+  schedule:
+    - cron: '0 7 * * *'   # daily 07:00 UTC
+  push:
+    branches: [main]
+    paths:
+      - 'camps/*/install.sh'
+      - 'scripts/check-install-urls.sh'
+  workflow_dispatch:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: bash scripts/check-install-urls.sh

--- a/.github/workflows/validate-install-consistency.yml
+++ b/.github/workflows/validate-install-consistency.yml
@@ -1,0 +1,26 @@
+name: Validate install.sh consistency
+
+on:
+  pull_request:
+    paths:
+      - 'camps/*/install.sh'
+      - 'camps/*/package.json'
+      - 'packages/*/package.json'
+      - 'scripts/validate-install-consistency.js'
+  push:
+    branches: [main]
+    paths:
+      - 'camps/*/install.sh'
+      - 'camps/*/package.json'
+      - 'packages/*/package.json'
+      - 'scripts/validate-install-consistency.js'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: node scripts/validate-install-consistency.js

--- a/scripts/check-install-urls.sh
+++ b/scripts/check-install-urls.sh
@@ -40,7 +40,25 @@ for camp_dir in "$REPO_ROOT"/camps/*/; do
     continue
   fi
 
-  base="${RELEASE_BASE}/${camp}-${ver}"
+  raw_base=$(sed -nE 's/^BASE="([^"]+)".*/\1/p' "$install" | head -1)
+  if [ -z "$raw_base" ]; then
+    echo "=== $camp ==="
+    echo "  [parse-error] could not extract BASE from $install"
+    FAILURES+=("[$camp] could not parse BASE")
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+  base=$(printf '%s' "$raw_base" | sed -e "s|\${CAMP_VERSION}|$ver|g" -e "s|\$CAMP_VERSION|$ver|g")
+
+  expected_base="${RELEASE_BASE}/${camp}-${ver}"
+  if [ "$base" != "$expected_base" ]; then
+    echo "=== $camp ($ver) ==="
+    echo "  [base-mismatch] install.sh BASE resolves to '$base', expected '$expected_base'"
+    FAILURES+=("[$camp] BASE mismatch: $base != $expected_base")
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
   echo "=== $camp ($ver) ==="
 
   while IFS= read -r suffix; do

--- a/scripts/check-install-urls.sh
+++ b/scripts/check-install-urls.sh
@@ -3,7 +3,7 @@
 #
 # Catches: CAMP_VERSION points to a tag that was never cut, or an asset is missing
 # from the release. Does NOT check internal consistency (see validate-install-consistency.js).
-set -uo pipefail
+set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 RELEASE_BASE="https://github.com/planetarium/CampForge/releases/download"

--- a/scripts/check-install-urls.sh
+++ b/scripts/check-install-urls.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# HEAD-check every URL referenced in camps/*/install.sh against actual GitHub Releases.
+#
+# Catches: CAMP_VERSION points to a tag that was never cut, or an asset is missing
+# from the release. Does NOT check internal consistency (see validate-install-consistency.js).
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+RELEASE_BASE="https://github.com/planetarium/CampForge/releases/download"
+
+FAIL=0
+CHECKED=0
+FAILURES=()
+
+check_url() {
+  local url="$1"
+  local code
+  code=$(curl -s -o /dev/null -w "%{http_code}" -I -L --max-time 15 "$url" || echo "000")
+  CHECKED=$((CHECKED + 1))
+  if [ "$code" = "200" ]; then
+    echo "  [200] $url"
+  else
+    echo "  [$code] $url"
+    FAILURES+=("[$code] $url")
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+for camp_dir in "$REPO_ROOT"/camps/*/; do
+  camp=$(basename "$camp_dir")
+  install="$camp_dir/install.sh"
+  [ -f "$install" ] || continue
+
+  ver=$(sed -nE 's/^CAMP_VERSION="?\$\{CAMP_VERSION:-([^}]+)\}"?/\1/p' "$install" | head -1)
+  if [ -z "$ver" ]; then
+    echo "=== $camp ==="
+    echo "  [parse-error] could not extract CAMP_VERSION from $install"
+    FAILURES+=("[$camp] could not parse CAMP_VERSION")
+    FAIL=$((FAIL + 1))
+    continue
+  fi
+
+  base="${RELEASE_BASE}/${camp}-${ver}"
+  echo "=== $camp ($ver) ==="
+
+  while IFS= read -r suffix; do
+    [ -n "$suffix" ] && check_url "${base}/${suffix}"
+  done < <(grep -oE '\$BASE/[^"[:space:]]+' "$install" | sed 's|\$BASE/||' | sort -u)
+done
+
+echo ""
+echo "checked $CHECKED URL(s), $FAIL failure(s)"
+
+if [ "$FAIL" -gt 0 ]; then
+  echo ""
+  echo "FAILURES:"
+  for f in "${FAILURES[@]}"; do
+    echo "  - $f"
+  done
+  exit 1
+fi

--- a/scripts/validate-install-consistency.js
+++ b/scripts/validate-install-consistency.js
@@ -76,7 +76,9 @@ function validateCamp(camp) {
   }
 
   const campTgzMatch = install.match(CAMP_FILES_LINE);
-  if (campTgzMatch && campTgzMatch[1] !== camp) {
+  if (!campTgzMatch) {
+    errors.push(`[${camp}] install.sh does not call install_camp_files "$BASE/camp-${camp}.tgz"`);
+  } else if (campTgzMatch[1] !== camp) {
     errors.push(`[${camp}] install_camp_files uses camp-${campTgzMatch[1]}.tgz but camp directory is '${camp}'`);
   }
 }

--- a/scripts/validate-install-consistency.js
+++ b/scripts/validate-install-consistency.js
@@ -31,7 +31,12 @@ function validateCamp(camp) {
   const campDir = path.join(CAMPS_DIR, camp);
   const installPath = path.join(campDir, 'install.sh');
   const pkgPath = path.join(campDir, 'package.json');
-  if (!fs.existsSync(installPath) || !fs.existsSync(pkgPath)) return;
+  const hasInstall = fs.existsSync(installPath);
+  const hasPkg = fs.existsSync(pkgPath);
+  if (!hasInstall && !hasPkg) return;
+  if (!hasInstall) errors.push(`[${camp}] missing required file: camps/${camp}/install.sh`);
+  if (!hasPkg) errors.push(`[${camp}] missing required file: camps/${camp}/package.json`);
+  if (!hasInstall || !hasPkg) return;
 
   const install = fs.readFileSync(installPath, 'utf8');
   const campPkg = readJson(pkgPath);

--- a/scripts/validate-install-consistency.js
+++ b/scripts/validate-install-consistency.js
@@ -1,0 +1,94 @@
+#!/usr/bin/env node
+// Validate internal consistency of camps/*/install.sh against package.json files.
+//
+// Catches: install.sh referencing tarball versions that don't match packages/*/package.json,
+// or dep lists that diverge between install.sh and camps/<camp>/package.json.
+// Does NOT check whether the referenced GitHub Release actually exists.
+
+const fs = require('fs');
+const path = require('path');
+
+const REPO_ROOT = path.resolve(__dirname, '..');
+const CAMPS_DIR = path.join(REPO_ROOT, 'camps');
+const PACKAGES_DIR = path.join(REPO_ROOT, 'packages');
+
+const TARBALL_LINE = /dependencies\.@campforge\/([a-z0-9-]+)=\$BASE\/campforge-([a-z0-9-]+)-(\d+\.\d+\.\d+)\.tgz/g;
+const CAMP_FILES_LINE = /install_camp_files\s+"\$BASE\/camp-([a-z0-9-]+)\.tgz"/;
+
+const errors = [];
+
+function readJson(p) {
+  return JSON.parse(fs.readFileSync(p, 'utf8'));
+}
+
+function pkgVersion(name) {
+  const p = path.join(PACKAGES_DIR, name, 'package.json');
+  if (!fs.existsSync(p)) return null;
+  return readJson(p).version;
+}
+
+function validateCamp(camp) {
+  const campDir = path.join(CAMPS_DIR, camp);
+  const installPath = path.join(campDir, 'install.sh');
+  const pkgPath = path.join(campDir, 'package.json');
+  if (!fs.existsSync(installPath) || !fs.existsSync(pkgPath)) return;
+
+  const install = fs.readFileSync(installPath, 'utf8');
+  const campPkg = readJson(pkgPath);
+  const campDeps = new Set(
+    Object.keys(campPkg.dependencies || {})
+      .filter((d) => d.startsWith('@campforge/'))
+      .map((d) => d.slice('@campforge/'.length))
+  );
+
+  const installDeps = new Set();
+  for (const m of install.matchAll(TARBALL_LINE)) {
+    const [, depName, fileName, version] = m;
+    installDeps.add(depName);
+
+    if (depName !== fileName) {
+      errors.push(`[${camp}] tarball name mismatch: @campforge/${depName} references campforge-${fileName}-${version}.tgz`);
+      continue;
+    }
+
+    const actual = pkgVersion(depName);
+    if (actual === null) {
+      errors.push(`[${camp}] install.sh references @campforge/${depName} but packages/${depName}/ does not exist`);
+    } else if (actual !== version) {
+      errors.push(`[${camp}] @campforge/${depName}: install.sh pins ${version} but packages/${depName}/package.json is ${actual}`);
+    }
+  }
+
+  for (const dep of campDeps) {
+    if (!installDeps.has(dep)) {
+      errors.push(`[${camp}] @campforge/${dep} is in camps/${camp}/package.json but not referenced in install.sh`);
+    }
+  }
+  for (const dep of installDeps) {
+    if (!campDeps.has(dep)) {
+      errors.push(`[${camp}] @campforge/${dep} is referenced in install.sh but not in camps/${camp}/package.json dependencies`);
+    }
+  }
+
+  const campTgzMatch = install.match(CAMP_FILES_LINE);
+  if (campTgzMatch && campTgzMatch[1] !== camp) {
+    errors.push(`[${camp}] install_camp_files uses camp-${campTgzMatch[1]}.tgz but camp directory is '${camp}'`);
+  }
+}
+
+const camps = fs.readdirSync(CAMPS_DIR).filter((d) => {
+  return fs.statSync(path.join(CAMPS_DIR, d)).isDirectory();
+});
+
+for (const camp of camps) {
+  validateCamp(camp);
+}
+
+if (errors.length > 0) {
+  console.error('install.sh consistency check FAILED:\n');
+  for (const e of errors) console.error('  - ' + e);
+  console.error(`\n${errors.length} issue(s). Update install.sh and/or package.json so they agree.`);
+  process.exit(1);
+}
+
+console.log(`install.sh consistency check OK (${camps.length} camps)`);


### PR DESCRIPTION
## Summary

Adds two independent CI checks to prevent the class of bug in #46 (installer pointing at a release that was never cut / missing assets). Complements the release-time fixes in #47 and the v8-admin-v1.3.0 release already cut.

### 1. `validate-install-consistency` — PR-time, internal consistency

Runs on PRs touching `camps/*/install.sh`, `camps/*/package.json`, or `packages/*/package.json`. Parses each camp's `install.sh` and verifies:

- Every `campforge-<name>-<ver>.tgz` reference matches `packages/<name>/package.json` version
- `@campforge/*` deps listed in `camps/<camp>/package.json` and `install.sh` agree (no orphans either direction)
- `install_camp_files "$BASE/camp-<X>.tgz"` uses the correct camp directory name

Fast (no network, no npm install). Catches internal drift, e.g. the #42/#44 scenario where a package bump landed without updating the installer.

### 2. `check-install-urls` — cron + main push, release-existence

Runs daily at 07:00 UTC, on pushes to main touching `camps/*/install.sh`, and on manual dispatch. For each `camps/*/install.sh`:

- Extracts the default `CAMP_VERSION`
- Derives the release URL base
- HEAD-checks every `$BASE/…` URL (tarballs, camp bundle, `install-common.sh`)

Fails the job if any returns non-200. This is what would have caught #46 directly, and it also found `9c-backoffice-v1.0.1` and `campforge-guide-v1.0.1` missing their `camp-<name>.tgz` (fixed in #47).

## Design notes

- Two checks, not one — internal consistency is a fast PR gate; URL existence requires the release to already exist, so it only makes sense after merge. Collapsing them would either slow PR CI or cause spurious failures at the bump-before-release window.
- No auto-issue on failure yet; Actions RED is enough. Issue automation can be layered on later if noise is low.
- Pure bash + Node with no deps. No Docker, no npm install in the fast path.

## Test plan

- [x] Clean run on current main: both checks exit 0 (26 URLs checked, all 200)
- [x] Synthetic failure test: package.json vs install.sh mismatch, missing dep, and wrong `camp-<X>.tgz` name all caught by consistency check
- [x] Synthetic failure test: URL checker correctly surfaced the two broken `camp-<name>.tgz` assets (addressed in #47)
- [ ] Confirm workflow triggers on this PR
- [ ] Confirm cron workflow can be manually dispatched after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)