### PR TITLE
fix(install): detach stdin so curl-bash piping doesn't race-truncate

### DIFF
--- a/camps/9c-backoffice/install.sh
+++ b/camps/9c-backoffice/install.sh
@@ -3,6 +3,12 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/9c-backoffice/install.sh | bash
 set -euo pipefail
 
+# When invoked via `curl ... | bash`, our stdin IS the script body bash is
+# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
+# race-read it, truncating us mid-script with cryptic syntax errors.
+# Detach unconditionally if stdin is not a terminal.
+[ -t 0 ] || exec < /dev/null
+
 CAMP_VERSION="${CAMP_VERSION:-v1.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/9c-backoffice-${CAMP_VERSION}"
 

--- a/camps/campforge-guide/install.sh
+++ b/camps/campforge-guide/install.sh
@@ -3,6 +3,12 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/campforge-guide/install.sh | bash
 set -euo pipefail
 
+# When invoked via `curl ... | bash`, our stdin IS the script body bash is
+# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
+# race-read it, truncating us mid-script with cryptic syntax errors.
+# Detach unconditionally if stdin is not a terminal.
+[ -t 0 ] || exec < /dev/null
+
 CAMP_VERSION="${CAMP_VERSION:-v1.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/campforge-guide-${CAMP_VERSION}"
 

--- a/camps/flex-ax/install.sh
+++ b/camps/flex-ax/install.sh
@@ -3,6 +3,12 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/flex-ax/install.sh | bash
 set -euo pipefail
 
+# When invoked via `curl ... | bash`, our stdin IS the script body bash is
+# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
+# race-read it, truncating us mid-script with cryptic syntax errors.
+# Detach unconditionally if stdin is not a terminal.
+[ -t 0 ] || exec < /dev/null
+
 CAMP_VERSION="${CAMP_VERSION:-v2.0.0}"
 BASE="https://github.com/planetarium/CampForge/releases/download/flex-ax-$CAMP_VERSION"
 

--- a/camps/v8-admin/install.sh
+++ b/camps/v8-admin/install.sh
@@ -3,6 +3,12 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/v8-admin/install.sh | bash
 set -euo pipefail
 
+# When invoked via `curl ... | bash`, our stdin IS the script body bash is
+# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
+# race-read it, truncating us mid-script with cryptic syntax errors.
+# Detach unconditionally if stdin is not a terminal.
+[ -t 0 ] || exec < /dev/null
+
 CAMP_VERSION="${CAMP_VERSION:-v1.3.0}"
 BASE="https://github.com/planetarium/CampForge/releases/download/v8-admin-${CAMP_VERSION}"
 


### PR DESCRIPTION
## Summary

`curl -fsSL .../camps/<camp>/install.sh | bash` is intermittently broken on a fresh environment — reproduced in the PR #49 verification at ~2/3 failure rate with cryptic errors like:

```
bash: line 32: syntax error near unexpected token '13'
```

The same `install.sh` runs cleanly when downloaded first and executed as a file. The fault is a stdin race that's been latent in all four camp installers.

## Root cause

In `curl ... | bash` mode, **bash's stdin is the script body itself** that bash is parsing. Child processes spawned from the script (`npm pkg set`, `npx skillpm install`, the `curl install-common.sh -o $TMP_COMMON` fallback, etc.) inherit that stdin and can race-read the remaining script bytes before bash gets to them — truncating the parser mid-statement.

This is a well-known footgun for `curl|bash` quickstart scripts. It only manifests when child processes happen to read from stdin and only when the OS scheduler lets them win the race against bash's own read — hence the non-determinism.

## Fix

Add this single line as the first executable statement after `set -euo pipefail` in each camp's `install.sh`:

```bash
[ -t 0 ] || exec < /dev/null
```

When stdin is not a terminal (i.e. we were piped to), redirect stdin to `/dev/null`. The installer never reads from stdin itself, so this is safe; child processes now inherit `/dev/null` and can't steal script bytes.

Applied identically to all four camps:

- `camps/flex-ax/install.sh`
- `camps/9c-backoffice/install.sh`
- `camps/v8-admin/install.sh`
- `camps/campforge-guide/install.sh`

## Effect / rollout

`install.sh` is **fetched live from `main`** by curl-bash users — so this fix takes effect for every camp the moment this PR merges, with no release re-cut required. The release tarball assets (`.tgz`) are unaffected.

(For users who installed via the embedded copy of `install.sh` inside an old camp tarball, they would need to re-fetch from `main` to pick up the fix — but the canonical curl-bash flow always pulls from `main` raw, so this is a non-issue in practice.)

## Test plan

- [x] Local syntax check (`bash -n`) on all four `install.sh`
- [x] `node scripts/validate-install-consistency.js` passes
- [ ] After merge: spot-check `curl -fsSL .../main/camps/flex-ax/install.sh | bash` in a clean tmp dir several times to confirm the race is gone (the failure was intermittent so a single success is insufficient — repeat 5+ times)
- [ ] Same spot-check for 9c-backoffice / v8-admin / campforge-guide if convenient

## Refs

- PR #49 (where the verification exposed this): https://github.com/planetarium/CampForge/pull/49
- Background reading on the curl|bash stdin race: https://www.davidpashley.com/articles/writing-robust-shell-scripts/

🤖 Generated with [Claude Code](https://claude.com/claude-code)