### PR TITLE
Revert #51: stdin redirect breaks curl-bash entirely

### DIFF
--- a/camps/9c-backoffice/install.sh
+++ b/camps/9c-backoffice/install.sh
@@ -3,12 +3,6 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/9c-backoffice/install.sh | bash
 set -euo pipefail
 
-# When invoked via `curl ... | bash`, our stdin IS the script body bash is
-# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
-# race-read it, truncating us mid-script with cryptic syntax errors.
-# Detach unconditionally if stdin is not a terminal.
-[ -t 0 ] || exec < /dev/null
-
 CAMP_VERSION="${CAMP_VERSION:-v1.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/9c-backoffice-${CAMP_VERSION}"
 

--- a/camps/campforge-guide/install.sh
+++ b/camps/campforge-guide/install.sh
@@ -3,12 +3,6 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/campforge-guide/install.sh | bash
 set -euo pipefail
 
-# When invoked via `curl ... | bash`, our stdin IS the script body bash is
-# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
-# race-read it, truncating us mid-script with cryptic syntax errors.
-# Detach unconditionally if stdin is not a terminal.
-[ -t 0 ] || exec < /dev/null
-
 CAMP_VERSION="${CAMP_VERSION:-v1.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/campforge-guide-${CAMP_VERSION}"
 

--- a/camps/flex-ax/install.sh
+++ b/camps/flex-ax/install.sh
@@ -3,12 +3,6 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/flex-ax/install.sh | bash
 set -euo pipefail
 
-# When invoked via `curl ... | bash`, our stdin IS the script body bash is
-# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
-# race-read it, truncating us mid-script with cryptic syntax errors.
-# Detach unconditionally if stdin is not a terminal.
-[ -t 0 ] || exec < /dev/null
-
 CAMP_VERSION="${CAMP_VERSION:-v2.0.0}"
 BASE="https://github.com/planetarium/CampForge/releases/download/flex-ax-$CAMP_VERSION"
 

--- a/camps/v8-admin/install.sh
+++ b/camps/v8-admin/install.sh
@@ -3,12 +3,6 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/v8-admin/install.sh | bash
 set -euo pipefail
 
-# When invoked via `curl ... | bash`, our stdin IS the script body bash is
-# parsing. Child processes (npm, curl, etc.) inherit that stdin and may
-# race-read it, truncating us mid-script with cryptic syntax errors.
-# Detach unconditionally if stdin is not a terminal.
-[ -t 0 ] || exec < /dev/null
-
 CAMP_VERSION="${CAMP_VERSION:-v1.3.0}"
 BASE="https://github.com/planetarium/CampForge/releases/download/v8-admin-${CAMP_VERSION}"
 


### PR DESCRIPTION
## Summary

Reverts #51 (\`fix(install): detach stdin so curl-bash piping doesn't race-truncate\`).

The fix was wrong: it makes `curl ... | bash` exit 0 with **zero install steps executed** on every invocation, leaving users with an empty workspace and no error message. Worse than the original race.

## What went wrong

PR #51 added this guard to all four camp installers:

```bash
[ -t 0 ] || exec < /dev/null
```

The intent was "if we're being piped to, detach our stdin so child processes (npm, curl) can't race-read the script body."

But in `curl ... | bash` mode, **bash's stdin _is_ the script body it's reading commands from**. `exec < /dev/null` redirects the command source to /dev/null, so bash silently EOFs at the line it executes the redirect on and exits 0. No syntax error, no output, no workspace.

In `bash install.sh` (file) mode the redirect is harmless because stdin is the user's terminal/null, not the script source — that's why the local `bash -n` syntax check and `bash install.sh` smoke test in #51 both looked fine.

## Verification of this revert

After applying this revert, `curl ... | bash` once again completes the full install in a fresh tmp dir (verified before opening this PR).

The original race condition (`bash: line N: syntax error near unexpected token '...'`) reported in #49 verification may or may not still be present — it was intermittent (~2/3 attempts in one observation) and could just as easily have been a transient flake during that test run. Re-investigation is warranted **before** trying another fix.

## Followups (deliberately not in this PR)

- Re-verify whether the original intermittent failure reproduces on a clean environment, with multiple attempts back-to-back (10+).
- If it really is a stdin race: the right shape of fix is one of:
  - apply `</dev/null` to each child-process invocation that risks reading stdin (`npm pkg set < /dev/null \\ ...`, `npx skillpm install < /dev/null`, etc.) — no effect on bash's own command source
  - or recommend `bash <(curl ...)` (process substitution) in the README rather than `curl | bash`
  - or some self-rewrite-to-tempfile-then-exec dance
- Either way the next attempt needs **end-to-end `curl | bash` smoke verification** before merge, not just `bash -n` and `bash install.sh`.

## Test plan

- [x] `node scripts/validate-install-consistency.js` passes locally
- [x] `bash -n` on all four reverted install.sh passes
- [ ] After merge: `curl ... | bash` smoke test in clean tmp dir confirms full install (this is the metric that should have gated #51)

🤖 Generated with [Claude Code](https://claude.com/claude-code)