### PR TITLE
fix: bootstrap Git Bash on Windows installs

### DIFF
--- a/camps/flex-ax-remote/INSTALL.md
+++ b/camps/flex-ax-remote/INSTALL.md
@@ -10,6 +10,10 @@
 - `jq` (used by the post-install token-extraction snippet)
 - bash (Windows: use WSL or Git Bash)
 
+On Windows, the installer will also try to bootstrap missing prerequisites via `winget`:
+- `OpenJS.NodeJS.LTS`
+- `Git.Git` (Git for Windows / Git Bash)
+
 ## Quick install
 
 ```bash

--- a/camps/flex-ax/INSTALL.md
+++ b/camps/flex-ax/INSTALL.md
@@ -9,6 +9,10 @@
 - curl
 - bash (Windows: use WSL, Git Bash, or see the PowerShell section)
 
+On Windows, the installer will also try to bootstrap missing prerequisites via `winget`:
+- `OpenJS.NodeJS.LTS`
+- `Git.Git` (Git for Windows / Git Bash)
+
 ## Quick install
 
 ```bash
@@ -65,6 +69,7 @@ PowerShell install script is tracked in [planetarium/CampForge#32](https://githu
 Recommended setup on Windows:
 - Use **Git Bash** as the default runtime shell for `flex-ax`, `gws`, and `gws-auth`
 - Use PowerShell only for one-time file placement / PATH setup when needed
+- If `Node.js` or `Git for Windows` is missing, the installer will try `winget install OpenJS.NodeJS.LTS` and `winget install Git.Git`
 
 ### Preferred path: Git Bash install
 

--- a/camps/flex-ax/INSTALL.md
+++ b/camps/flex-ax/INSTALL.md
@@ -21,6 +21,7 @@ curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/fl
 
 By default, the installer creates and uses `./workspace/`.
 Override with `WORKSPACE=/your/path` if you want a different install location.
+If the path contains spaces, quote it: `WORKSPACE=\"/path/with spaces\" bash install.sh`.
 
 ## What the script does
 

--- a/camps/flex-ax/install.sh
+++ b/camps/flex-ax/install.sh
@@ -57,6 +57,8 @@ case "$PLATFORM" in
   claude-code)
     # UserPromptSubmit hook: check data freshness on each prompt
     CHECK_CMD="$(pwd)/scripts/check-freshness.sh"
+    CHECK_CMD_ESCAPED="${CHECK_CMD//\\/\\\\}"
+    CHECK_CMD_ESCAPED="${CHECK_CMD_ESCAPED//\"/\\\"}"
     if [ -f ".claude/settings.json" ]; then
       echo "  [action-required] Add this hook to .claude/settings.json:"
     else
@@ -65,7 +67,7 @@ case "$PLATFORM" in
   "hooks": {
     "UserPromptSubmit": [
       {
-        "command": "bash $CHECK_CMD",
+        "command": "bash \"$CHECK_CMD_ESCAPED\"",
         "description": "Check flex-ax data freshness and crawl if stale"
       }
     ]

--- a/scripts/install-common.sh
+++ b/scripts/install-common.sh
@@ -33,6 +33,8 @@ refresh_node_path() {
   if is_windows; then
     [ -n "${LOCALAPPDATA:-}" ] && [ -d "$LOCALAPPDATA/Programs/nodejs" ] && path_append "$LOCALAPPDATA/Programs/nodejs"
     [ -d "/c/Program Files/nodejs" ] && path_append "/c/Program Files/nodejs"
+    [ -d "/c/Program Files/Git/bin" ] && path_append "/c/Program Files/Git/bin"
+    [ -d "/c/Program Files/Git/cmd" ] && path_append "/c/Program Files/Git/cmd"
   elif [ "$(uname -s)" = "Darwin" ]; then
     if command -v brew >/dev/null 2>&1; then
       local prefix
@@ -46,7 +48,32 @@ refresh_node_path() {
   fi
 }
 
+ensure_windows_git_runtime() {
+  if ! is_windows; then
+    return
+  fi
+
+  if command -v git >/dev/null 2>&1; then
+    return
+  fi
+
+  echo "  Ensuring Git for Windows (Git Bash runtime)..."
+  if command -v winget >/dev/null 2>&1; then
+    winget install -e --id Git.Git \
+      --accept-package-agreements \
+      --accept-source-agreements >/dev/null 2>&1 || {
+      echo "  [warn] winget Git for Windows install failed."
+      return
+    }
+    refresh_node_path
+  fi
+}
+
 ensure_node_runtime() {
+  if is_windows; then
+    ensure_windows_git_runtime
+  fi
+
   if have_node_runtime; then
     return
   fi

--- a/scripts/test-install.sh
+++ b/scripts/test-install.sh
@@ -74,6 +74,38 @@ run_installer() {
     ' 2>&1
 }
 
+run_installer_with_workspace() {
+  local dist="$1" platform="$2" workspace_name="$3"
+  docker run --rm \
+    -v "$dist:/srv" \
+    -e "CAMPFORGE_PLATFORM=$platform" \
+    -e "WORKSPACE_NAME=$workspace_name" \
+    node:20 bash -c '
+      set -euo pipefail
+      python3 -m http.server 8080 --directory /srv 2>/dev/null &
+      SERVER_PID=$!
+      SERVER_READY=false
+      for i in $(seq 1 10); do
+        if curl -sf http://localhost:8080/ >/dev/null 2>&1; then
+          SERVER_READY=true
+          break
+        fi
+        sleep 0.5
+      done
+      if [ "$SERVER_READY" != "true" ]; then
+        echo "[error] HTTP server failed to start" >&2
+        exit 1
+      fi
+      cd /tmp
+      WORKSPACE="$WORKSPACE_NAME" bash /srv/install.sh 2>&1
+      echo "---SPACE_WORKSPACE_SKILLS---"
+      find "$WORKSPACE_NAME/.agents/skills" -maxdepth 2 -name SKILL.md -type f 2>/dev/null | sort
+      echo "---SPACE_WORKSPACE_HOOKS---"
+      cat "$WORKSPACE_NAME/.claude/settings.json" 2>/dev/null || echo "(no settings.json)"
+      kill $SERVER_PID 2>/dev/null || true
+    ' 2>&1
+}
+
 for CAMP in "${CAMPS[@]}"; do
   echo ""
   echo "========================================="
@@ -362,6 +394,39 @@ for CAMP in "${CAMPS[@]}"; do
       FAIL=$((FAIL + 1))
     fi
   done
+
+  if [ "$CAMP" = "flex-ax" ]; then
+    echo ""
+    echo "  --- Workspace Path With Spaces ---"
+    SPACE_RESULT=$(run_installer_with_workspace "$DIST" "claude-code" "workspace with spaces")
+    SPACE_PASS=true
+
+    echo "    Verifying skill install under spaced workspace path..."
+    for skill in "${EXPECTED_SKILLS[@]}"; do
+      if echo "$SPACE_RESULT" | grep -q "workspace with spaces/.agents/skills/$skill/SKILL.md"; then
+        echo "      ✓ $skill/SKILL.md"
+      else
+        echo "      ✗ $skill/SKILL.md MISSING"
+        SPACE_PASS=false
+      fi
+    done
+
+    echo "    Verifying freshness hook command quoting..."
+    if echo "$SPACE_RESULT" | grep -Fq '"command": "bash \"/tmp/workspace with spaces/scripts/check-freshness.sh\""'; then
+      echo "      ✓ .claude/settings.json quotes spaced script path"
+    else
+      echo "      ✗ .claude/settings.json does not quote spaced script path"
+      SPACE_PASS=false
+    fi
+
+    if $SPACE_PASS; then
+      echo "    => PASS"
+      PASS=$((PASS + 1))
+    else
+      echo "    => FAIL"
+      FAIL=$((FAIL + 1))
+    fi
+  fi
 
   # -------------------------------------------------------
   # Test conflict cases (existing files in workspace)


### PR DESCRIPTION
## Summary
- bootstrap Git for Windows via winget when Windows installs are missing Git Bash
- document that the installer now attempts to install both OpenJS.NodeJS.LTS and Git.Git on Windows
- keep flex-ax and flex-ax-remote INSTALL.md aligned with the new bootstrap behavior

## Verification
- bash -n scripts/install-common.sh
- bash scripts/test-install.sh flex-ax
- rg -n -- '--auth\b' .
