### PR TITLE
Improve gws-sheets Windows guidance for localized sheet names and JSON-heavy flows

### DIFF
--- a/camps/flex-ax-remote/install.sh
+++ b/camps/flex-ax-remote/install.sh
@@ -29,7 +29,7 @@ npm pkg set \
   "dependencies.@campforge/a2x=$BASE/campforge-a2x-0.1.0.tgz" \
   "dependencies.@campforge/gql-ops=$BASE/campforge-gql-ops-0.2.0.tgz" \
   "dependencies.@campforge/gws-auth=$BASE/campforge-gws-auth-0.1.0.tgz" \
-  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.2.tgz" \
+  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.3.tgz" \
   "dependencies.@campforge/gws-gmail=$BASE/campforge-gws-gmail-0.1.1.tgz" \
   "dependencies.@campforge/gws-drive=$BASE/campforge-gws-drive-0.1.1.tgz"
 

--- a/camps/flex-ax/install.sh
+++ b/camps/flex-ax/install.sh
@@ -30,7 +30,7 @@ npm pkg set \
   "dependencies.@campforge/flex-query=$BASE/campforge-flex-query-0.1.0.tgz" \
   "dependencies.@campforge/flex-crawl=$BASE/campforge-flex-crawl-0.1.0.tgz" \
   "dependencies.@campforge/gws-auth=$BASE/campforge-gws-auth-0.1.0.tgz" \
-  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.2.tgz" \
+  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.3.tgz" \
   "dependencies.@campforge/gws-gmail=$BASE/campforge-gws-gmail-0.1.1.tgz" \
   "dependencies.@campforge/gws-drive=$BASE/campforge-gws-drive-0.1.1.tgz"
 

--- a/camps/v8-admin/install.sh
+++ b/camps/v8-admin/install.sh
@@ -14,7 +14,7 @@ npm pkg set \
   "dependencies.@campforge/v8-api=$BASE/campforge-v8-api-1.1.0.tgz" \
   "dependencies.@campforge/gql-ops=$BASE/campforge-gql-ops-0.2.0.tgz" \
   "dependencies.@campforge/gws-auth=$BASE/campforge-gws-auth-0.1.0.tgz" \
-  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.2.tgz"
+  "dependencies.@campforge/gws-sheets=$BASE/campforge-gws-sheets-0.1.3.tgz"
 
 npx skillpm install
 

--- a/packages/gws-sheets/package.json
+++ b/packages/gws-sheets/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@campforge/gws-sheets",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Google Sheets operations skill for CampForge camps",
   "keywords": ["agent-skill", "google-sheets", "gws", "campforge"],
   "license": "Apache-2.0",

--- a/packages/gws-sheets/skills/gws-sheets/SKILL.md
+++ b/packages/gws-sheets/skills/gws-sheets/SKILL.md
@@ -119,8 +119,8 @@ gws sheets +read --spreadsheet <ID> --range Sheet1 --dry-run
 
 ### Create new spreadsheet with initial data
 
-1. `gws sheets spreadsheets create --json '{"properties": {"title": "..."}}'` -> get new spreadsheet ID
-2. `gws sheets +append --spreadsheet <NEW_ID> --json-values '[["Header1","Header2"],[...]]'`
+1. `gws sheets spreadsheets create --json '{"properties": {"title": "..."}}'` -> capture **both** `spreadsheetId` and `sheets[0].properties.title` from the response. The first sheet's title is locale-dependent (e.g. `시트1` on Korean accounts, `Sheet1` on English), so do not hardcode `Sheet1!A1` in subsequent ranges -- use the title returned by `create`.
+2. `gws sheets +append --spreadsheet <NEW_ID> --json-values '[["Header1","Header2"],[...]]'` (defaults to the first sheet), or pass the actual title in `--params` `range` for `values update`/`append`.
 3. Optionally share: `gws drive permissions create ...`
 
 ### Find and update specific spreadsheet
@@ -151,23 +151,48 @@ command -v gws-auth
    `\uXXXX` escapes instead of raw Unicode.
 4. After any write containing non-ASCII text, immediately re-read a small
    range such as `A1:C5` to verify the stored characters.
-5. Avoid passing raw non-ASCII JSON through PowerShell into `gws.cmd` unless
-   code page and quoting behavior are already known to be safe.
+5. **Avoid** `gws.cmd --json $json` directly from PowerShell -- variable
+   interpolation reshapes quotes and produces `Invalid --json body`. The
+   same applies to deeply nested `bash -lc '... --json ... '` one-liners,
+   where the inner JSON gets mangled by outer quoting.
 
-If Git Bash is unavailable but `bash` is still present, a safer fallback is to
-write the command into a UTF-8 without BOM script and execute that script with
-`bash` instead of pasting raw JSON directly into PowerShell:
+### Windows-safe end-to-end example
+
+For JSON-heavy flows, write the whole workflow into a UTF-8 (no BOM) bash
+script and run it from Git Bash. This is the prescriptive Windows path for
+`create -> write -> verify` with non-ASCII content:
 
 ```bash
-cat > write-sheet.sh <<'EOF'
-gws sheets spreadsheets values update \
-  --params '{"spreadsheetId":"<ID>","range":"A1","valueInputOption":"USER_ENTERED"}' \
+cat > sheets-flow.sh <<'EOF'
+set -euo pipefail
+
+# gws-auth status alone is not enough -- gws picks up the OAuth token from
+# this env var, so export it before any gws call in the same session.
+export GOOGLE_WORKSPACE_CLI_TOKEN="$(gws-auth token)"
+
+# 1. Create. Read both spreadsheetId AND first sheet title from the
+#    response; the default title is locale-dependent (e.g. Korean accounts
+#    get a localized name, not "Sheet1"), so hardcoding "Sheet1!A1" yields
+#    "Unable to parse range".
+CREATE=$(gws sheets spreadsheets create \
+  --json '{"properties":{"title":"\uD68C\uC0AC \uBA85\uB2E8"}}')
+SID=$(node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).spreadsheetId" <<<"$CREATE")
+TITLE=$(node -p "JSON.parse(require('fs').readFileSync(0,'utf8')).sheets[0].properties.title" <<<"$CREATE")
+
+# 2. Write -- build --params via node so $SID/$TITLE are JSON-quoted safely.
+PARAMS=$(node -e 'console.log(JSON.stringify({spreadsheetId:process.argv[1],range:process.argv[2]+"!A1",valueInputOption:"USER_ENTERED"}))' "$SID" "$TITLE")
+gws sheets spreadsheets values update --params "$PARAMS" \
   --json '{"values":[["\uD68C\uC0AC","ACME"],["\uC0C1\uD0DC","\uC815\uC0C1"]]}'
+
+# 3. Verify the stored characters round-tripped correctly.
+gws sheets +read --spreadsheet "$SID" --range "$TITLE!A1:B2"
 EOF
 
-bash write-sheet.sh
-gws sheets +read --spreadsheet <ID> --range "A1:B2"
+bash sheets-flow.sh
 ```
+
+`node -p` is used instead of `jq` because Git Bash on Windows does not ship
+`jq` by default, but Node is already present (gws is an npm package).
 
 ## Notes
 


### PR DESCRIPTION
## Summary
- Make the locale-dependent default sheet title (`시트1` on Korean accounts, not `Sheet1`) explicit in the `Create new spreadsheet with initial data` workflow, with instructions to capture both `spreadsheetId` and `sheets[0].properties.title` from the create response.
- Add a prescriptive Windows-safe end-to-end example covering token export → create → ID/title extraction → values update → verify read, run from a UTF-8 (no BOM) bash script. Uses `node -p` (not `jq`) so it works on Git Bash for Windows out of the box.
- Call out the PowerShell `gws.cmd --json $json` and nested `bash -lc '... --json ...'` anti-patterns that produce `Invalid --json body`.
- Bump `@campforge/gws-sheets` to 0.1.3 and update tarball references in `camps/v8-admin`, `camps/flex-ax`, `camps/flex-ax-remote`.

Closes #58.

## Test plan
- [ ] Re-run the failing flow from #58 on Windows + Korean account using the new end-to-end example, confirm create/write/verify all succeed.
- [ ] Confirm `gws sheets +read` against the actual returned title round-trips Korean characters.
- [ ] After release, install one affected camp (e.g. v8-admin) via `install.sh` and confirm `@campforge/gws-sheets@0.1.3` is resolved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)