### PR TITLE
Bump camp release defaults after gws-sheets 0.1.3 release

### DIFF
--- a/camps/flex-ax-remote/install.sh
+++ b/camps/flex-ax-remote/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/flex-ax-remote/install.sh | bash
 set -euo pipefail
 
-CAMP_VERSION="${CAMP_VERSION:-v2.0.1}"
+CAMP_VERSION="${CAMP_VERSION:-v2.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/flex-ax-remote-$CAMP_VERSION"
 
 WS="${WORKSPACE:-workspace}"

--- a/camps/flex-ax/install.sh
+++ b/camps/flex-ax/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/flex-ax/install.sh | bash
 set -euo pipefail
 
-CAMP_VERSION="${CAMP_VERSION:-v3.0.1}"
+CAMP_VERSION="${CAMP_VERSION:-v3.0.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/flex-ax-$CAMP_VERSION"
 
 WS="${WORKSPACE:-workspace}"

--- a/camps/v8-admin/install.sh
+++ b/camps/v8-admin/install.sh
@@ -3,7 +3,7 @@
 # Usage: curl -fsSL https://raw.githubusercontent.com/planetarium/CampForge/main/camps/v8-admin/install.sh | bash
 set -euo pipefail
 
-CAMP_VERSION="${CAMP_VERSION:-v1.3.1}"
+CAMP_VERSION="${CAMP_VERSION:-v1.3.2}"
 BASE="https://github.com/planetarium/CampForge/releases/download/v8-admin-${CAMP_VERSION}"
 
 WS="${WORKSPACE:-workspace}"


### PR DESCRIPTION
## Summary
Follow-up to #59 and the v8-admin-v1.3.2 / flex-ax-v3.0.2 / flex-ax-remote-v2.0.2 releases.

The previous PR pointed each camp's `install.sh` at `campforge-gws-sheets-0.1.3.tgz`, but the default `CAMP_VERSION` was still the older release tag, which does not contain the 0.1.3 tarball. This bumps the defaults so a fresh `curl | bash` install pulls the correct release.

- v8-admin: v1.3.1 -> v1.3.2
- flex-ax: v3.0.1 -> v3.0.2
- flex-ax-remote: v2.0.1 -> v2.0.2

Same pattern as 3312ccc.

## Test plan
- [ ] CI install/validation workflows green.
- [ ] After merge, run a fresh `curl -fsSL .../install.sh | bash` for one camp and confirm it pulls 0.1.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)