### PR TITLE
[codex] Improve flex-ax Windows install guidance

### DIFF
--- a/camps/flex-ax/INSTALL.md
+++ b/camps/flex-ax/INSTALL.md
@@ -23,6 +23,10 @@ By default, the installer creates and uses `./workspace/`.
 Override with `WORKSPACE=/your/path` if you want a different install location.
 If the path contains spaces, quote it: `WORKSPACE=\"/path/with spaces\" bash install.sh`.
 
+On Windows, run this command from **Git Bash**, not from PowerShell. In
+PowerShell, `curl` may resolve to `Invoke-WebRequest` instead of the curl
+executable expected by the pipe-to-bash install command.
+
 ## What the script does
 
 1. **Skill packages** — `npm pkg set` + `npx skillpm install` (skillpm resolves skill doc dependencies into `.agents/skills/`)
@@ -83,6 +87,14 @@ gws --version
 command -v gws-auth
 ```
 
+For SQL checks on Windows, keep using Git Bash so `OUTPUT_DIR` and quoting
+behave the same way as the installer:
+
+```bash
+export OUTPUT_DIR="$(pwd)/output/<customerIdHash>"
+flex-ax query "SELECT * FROM users LIMIT 5"
+```
+
 If `flex-ax query` fails later with an export-dir error, point `OUTPUT_DIR` at a concrete export directory before querying:
 
 ```bash
@@ -97,11 +109,16 @@ flex-ax query "SELECT * FROM users LIMIT 5"
 Since `flex-cli@0.7.0`, the official install is a standalone executable and the recommended auth flow is `login` / OS keyring storage.
 
 ```bash
-flex-ax login
+flex-ax login --gui
 flex-ax status
 flex-ax crawl
 flex-ax import
 ```
+
+Use `flex-ax login --gui` for Codex, CI-adjacent terminals, and other
+non-interactive agent environments. It opens a platform dialog and avoids
+stdin/password prompt issues. Plain `flex-ax login` is still fine in a fully
+interactive shell.
 
 Non-interactive environments can still use env vars:
 
@@ -116,6 +133,9 @@ Notes:
 - `flex-ax login` stores the email in `~/.flex-ax/config.json`
 - The password is stored in the OS keyring, or can be injected via `FLEX_PASSWORD` / `--password-stdin`
 - `query` now expects `OUTPUT_DIR` to point at a concrete export directory when multiple customer exports exist
+- Run `flex-ax query` commands sequentially. The imported SQLite database can
+  report `database is locked` or `disk I/O error` when multiple agent queries
+  read it concurrently.
 
 Example:
 
@@ -135,6 +155,10 @@ gws-auth login --scope gmail.modify --scope spreadsheets --scope drive.file
 Verify access after login:
 
 ```bash
+gws-auth status
 export GOOGLE_WORKSPACE_CLI_TOKEN="$(gws-auth token)"
 gws gmail users getProfile --params '{"userId":"me"}'
 ```
+
+If a required scope is missing from `gws-auth status`, run `gws-auth login`
+again with the full scope list.

--- a/camps/flex-ax/identity/AGENTS.md
+++ b/camps/flex-ax/identity/AGENTS.md
@@ -1,5 +1,13 @@
 # Operating Rules
 
+## Windows / Codex runtime notes
+
+- Prefer `flex-ax login --gui` when stdin is not a real interactive terminal.
+- On Windows, use Git Bash for install, auth, crawl, and import commands.
+- Use Git Bash for SQL checks too, with `OUTPUT_DIR="$(pwd)/output/<customerIdHash>"`.
+- Run `flex-ax query` commands sequentially; concurrent reads can lock the
+  imported SQLite database.
+
 ## Startup
 
 1. Check required environment variables — ask user if not set

--- a/camps/flex-ax/install.sh
+++ b/camps/flex-ax/install.sh
@@ -95,3 +95,19 @@ BOOTMD
 esac
 
 echo "flex-ax camp installed"
+cat <<NEXTSTEPS
+
+Next steps:
+  cd $WS
+  export PATH="\$(pwd)/.local/bin:\$PATH"
+  flex-ax --version
+  flex-ax login --gui
+  flex-ax status
+
+To load queryable flex data:
+  flex-ax crawl
+  flex-ax import
+
+If import creates multiple output/<customerIdHash>/ directories, set OUTPUT_DIR
+to the specific export before querying.
+NEXTSTEPS

--- a/camps/flex-ax/knowledge/login-setup.md
+++ b/camps/flex-ax/knowledge/login-setup.md
@@ -5,11 +5,16 @@
 ## Recommended flow
 
 ```bash
-flex-ax login
+flex-ax login --gui
 flex-ax status
 flex-ax crawl
 flex-ax import
 ```
+
+Use `flex-ax login --gui` in Codex, Windows Git Bash launched by an agent, or
+any environment where stdin prompts may not be interactive. Use plain
+`flex-ax login` only when the user is directly typing in a fully interactive
+terminal.
 
 `login` 성공 시:
 - 이메일은 `~/.flex-ax/config.json` 에 저장된다
@@ -40,5 +45,18 @@ printf '%s' "$FLEX_PASSWORD" | flex-ax login --password-stdin
 export OUTPUT_DIR="$HOME/.flex-ax-data/output/<customerIdHash>"
 flex-ax query "SELECT * FROM users LIMIT 5"
 ```
+
+## Windows agent notes
+
+Use Git Bash for install, auth, crawl, import, and SQL checks. Keeping the
+whole flow in Bash avoids PowerShell-specific quoting differences:
+
+```bash
+export OUTPUT_DIR="$(pwd)/output/<customerIdHash>"
+flex-ax query "SELECT * FROM users LIMIT 5"
+```
+
+Run `flex-ax query` commands sequentially. Concurrent reads can trigger SQLite
+`database is locked` or `disk I/O error` failures.
 
 지정하지 않으면 `export 디렉터리를 명시적으로 지정해 주세요` 오류가 날 수 있다.

--- a/scripts/install-common.sh
+++ b/scripts/install-common.sh
@@ -26,7 +26,10 @@ path_append() {
 have_node_runtime() {
   command -v node >/dev/null 2>&1 &&
     command -v npm >/dev/null 2>&1 &&
-    command -v npx >/dev/null 2>&1
+    command -v npx >/dev/null 2>&1 &&
+    node -v >/dev/null 2>&1 &&
+    npm -v >/dev/null 2>&1 &&
+    npx -v >/dev/null 2>&1
 }
 
 refresh_node_path() {
@@ -255,7 +258,7 @@ install_a2x() {
 # Install flex-ax CLI from GitHub Release.
 # Since flex-cli 0.7.x, releases are standalone executables rather than npm tarballs.
 install_flex_ax() {
-  local version="${FLEX_AX_VERSION:-0.8.1}"
+  local version="${FLEX_AX_VERSION:-0.8.3}"
   local tag="flex-cli@${version}"
 
   echo ":: Installing flex-ax CLI (${tag})..."


### PR DESCRIPTION
## Summary

- Install flex-ax 0.8.3 by default so `login --gui` is available immediately.
- Print post-install next steps for PATH setup, GUI login, status, crawl/import, and `OUTPUT_DIR` selection.
- Expand flex-ax install and agent docs with Windows/Codex guidance that keeps install, auth, crawl/import, and query examples on Git Bash.
- Harden Node runtime detection by checking that `node`, `npm`, and `npx` actually execute, not just that they resolve on PATH.

## Why

A Windows/Codex install surfaced several rough edges: PowerShell `curl` alias confusion before Git Bash is used, a stale/broken Node resolution path, `flex-ax login` failing in non-interactive terminals before `--gui` was visible, and SQLite lock errors from concurrent query checks.

## Validation

- `node scripts/validate-install-consistency.js`
- `bash scripts/check-install-urls.sh`
- `bash -n scripts/install-common.sh`
- `bash -n camps/flex-ax/install.sh`
- Verified flex-ax 0.8.3 release assets return HTTP 200 for Windows x64, Linux x64, and Darwin arm64.