### PR TITLE
v8-api: opaque-response mutation guard + absorb production bot's useful skill additions

### DIFF
--- a/packages/v8-api/skills/v8-api/SKILL.md
+++ b/packages/v8-api/skills/v8-api/SKILL.md
@@ -76,7 +76,7 @@ echo "=== Verse ===" ; gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" --queryFi
 | `users-search.gql` | Search users | `{"keyword":"…","limit":20}` |
 | `users-low-balance.gql` | Low balance users | `{"threshold":5,"limit":20}` |
 | `comments-list.gql` | List/search comments | `{"limit":50}` or `{"searchType":"…","keyword":"…","filter":"…"}` |
-| `verse-list.gql` | List verses | `{"limit":20,"featured":"ONLY"}` |
+| `verse-list.gql` | List verses (optionally filter by `userUid`) | `{"limit":20,"featured":"ONLY"}` or `{"userUid":"<uid>","limit":50}` |
 | `game-payments-list.gql` | List game payments | `{"limit":20}` |
 | `game-payment-items-list.gql` | Payment items | `{"gamePaymentId":"<id>","limit":20}` |
 
@@ -96,6 +96,9 @@ gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerBa
 
 # Update a verse's admin-only fields (visibility, isHiddenFromRecommendation, allowRemix, featured, ...)
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerAdminUpdateVerse(verseId: "<verseId>", verseUpdateDtoInput: {visibility: UNLISTED, isHiddenFromRecommendation: true, allowRemix: false}) }' -l
+
+# Batch expire credits (userUids: max 1000)
+gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerBatchExpireCredits(batchExpireCreditsDtoInput: {userUids: ["<uid1>","<uid2>"]}) { success failed failedUids executionTimeMs } }' -l
 
 # Trigger analytics
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerTriggerCalculateQualityScores { success executionTimeMs } }' -l

--- a/packages/v8-api/skills/v8-api/SKILL.md
+++ b/packages/v8-api/skills/v8-api/SKILL.md
@@ -94,11 +94,26 @@ gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerCr
 # Delete comments
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerBatchCommentAction(batchCommentActionDtoInput: {commentIds: [1,2,3], action: "delete"}) { processed failed errors } }' -l
 
+# Update a verse's admin-only fields (visibility, isHiddenFromRecommendation, allowRemix, featured, ...)
+gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerAdminUpdateVerse(verseId: "<verseId>", verseUpdateDtoInput: {visibility: UNLISTED, isHiddenFromRecommendation: true, allowRemix: false}) }' -l
+
 # Trigger analytics
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerTriggerCalculateQualityScores { success executionTimeMs } }' -l
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerTriggerUpdateTrendingScores { success executionTimeMs } }' -l
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerTriggerMissionRankCalculation { success executionTimeMs } }' -l
 ```
+
+### ⚠️ Opaque-response mutations
+
+Some admin mutations — notably `adminControllerAdminUpdateVerse` — are typed as nullable scalars and return `{"data":{"<field>":null}}` **regardless of whether the change was applied**. The response shape on a silent failure is byte-identical to the response on a successful application.
+
+Consequences for any code or ad-hoc script that calls these:
+
+- **Never** infer success by grepping the response for the field name. Substring matches like `grep '"adminControllerAdminUpdateVerse"'` pass on every call, including silent failures, and will report `failed: 0` for runs where nothing was applied.
+- **Never** count `success` as "the mutation returned without an error envelope". A null payload is the normal return on success, so absence of `errors` carries no signal either.
+- **The only valid success check is a re-fetch.** Issue an admin verse query right after the mutation and compare the intended fields (`visibility`, `isHiddenFromRecommendation`, `allowRemix`, etc.) against the payload you sent. If they don't match, treat the call as failed and retry — do not trust the mutation response.
+
+This rule applies to any mutation whose return type is a nullable scalar (`String`, `Boolean`, etc.) rather than a structured `{ success, ... }` object. When in doubt, re-fetch.
 
 ## Common Workflows
 
@@ -111,6 +126,20 @@ gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerTr
 1. `--queryFile comments-list.gql` -j `{"limit":50}` → scan for patterns
 2. `--queryFile comments-list.gql` -j `{"searchType":"USEREMAIL","keyword":"<email>","filter":"ALL"}`
 3. inline mutation `adminControllerBatchCommentAction` with `commentIds`, `action: "delete"`
+
+## Bulk mutations (multi-target writes)
+
+When applying the same admin mutation across many targets (verses, users, comments), do **not** write an ad-hoc one-shot loop that infers success from the mutation response. See "Opaque-response mutations" above — for several admin mutations the response is null whether the change was applied or not, and a naive loop will report `failed: 0` for a run where most targets were silently skipped.
+
+Use this structure instead:
+
+1. **Batch.** Chunk the target list (e.g. 100 per batch). Do not fire thousands of mutations as one tight sequential loop with no checkpoints. Long unbroken loops also make token expiry mid-run a silent failure mode rather than an obvious one.
+2. **Refresh the token at batch boundaries.** If `$V8_TOKEN` is close to expiry, re-run `eval $(bash "$V8_SKILL_DIR/v8-auth.sh")` between batches. A run that started with a fresh token can still hit auth-induced silent failures partway through a long loop.
+3. **Verify by re-fetch, not by mutation response.** After each mutation (or at minimum a per-batch sample), query the target with an admin verse / user / comment read and confirm the intended fields are set to the intended values. `grep`, exit codes, and "the mutation returned without an error" are not evidence of application.
+4. **Count what was verified, not what was called.** When reporting back to the user, distinguish "calls issued" from "verified applied". `failed: 0` from a loop, on its own, is misleading — it only means the calls went out.
+5. **Sanity-check the per-target distribution after each batch.** Silent failures tend to cluster (e.g. all of user A's verses applied, none of user B's). If the per-target applied rate suddenly drops to near-zero, stop the run and investigate — do not keep going on the assumption that subsequent batches will recover.
+
+If any batch fails verification, stop and report. Keep a list of unverified target IDs so the run can be resumed against the unapplied subset rather than re-running the whole input list.
 
 ## Notes
 

--- a/packages/v8-api/skills/v8-api/queries/comments-list.gql
+++ b/packages/v8-api/skills/v8-api/queries/comments-list.gql
@@ -1,6 +1,6 @@
 query ($limit: Float, $page: Float, $searchType: SearchType, $keyword: String, $filter: Filter) {
   adminCommentsResponseDto(limit: $limit, page: $page, searchType: $searchType, keyword: $keyword, filter: $filter) {
-    comments { id content userDisplayName userEmail verseTitle verseShortId isDeleted likes isReply }
+    comments { id content userDisplayName userEmail verseTitle verseShortId isDeleted likes isReply createdAt }
     total page totalPages
   }
 }

--- a/packages/v8-api/skills/v8-api/queries/verse-list.gql
+++ b/packages/v8-api/skills/v8-api/queries/verse-list.gql
@@ -1,6 +1,6 @@
-query ($limit: Float, $page: Float, $category: String, $featured: Featured, $sortBy: SortBy, $tag: Tag2) {
-  adminVerseListResponseDto(limit: $limit, page: $page, category: $category, featured: $featured, sortBy: $sortBy, tag: $tag) {
-    items { verseId verseShortId title visibility featured showcase createdAt userDisplayName }
+query ($limit: Float, $page: Float, $category: String, $featured: Featured, $sortBy: SortBy, $tag: Tag2, $userUid: String) {
+  adminVerseListResponseDto(limit: $limit, page: $page, category: $category, featured: $featured, sortBy: $sortBy, tag: $tag, userUid: $userUid) {
+    items { verseId verseShortId title visibility featured showcase createdAt userDisplayName userUid }
     total page limit
   }
 }

--- a/packages/v8-api/skills/v8-api/references/admin-api.md
+++ b/packages/v8-api/skills/v8-api/references/admin-api.md
@@ -107,6 +107,8 @@ Key admin-only fields in `VerseUpdateDto`:
 - `visibility`: `public` | `unlisted` | `private`
 - `colors`: `{ primary, secondary, tertiary, quaternary }`
 
+> ⚠️ **GraphQL response is opaque.** The GraphQL counterpart `adminControllerAdminUpdateVerse` returns `null` regardless of whether the update was applied — the response shape on silent failure is byte-identical to success. Do **not** infer success from the mutation response (grep, error-envelope absence, exit code). Re-fetch the verse and compare the target fields. See `SKILL.md` → "Opaque-response mutations" and "Bulk mutations" for the required pattern.
+
 ---
 
 ## Game Payments


### PR DESCRIPTION
## Summary

Two related changes for the v8-admin-assist incident, originally split across #62 and #63, now unified into one PR.

1. **Document opaque-response mutations + require re-fetch verification.** `adminControllerAdminUpdateVerse` returns `null` whether or not the change was applied — the response on silent failure is byte-identical to success. A recent bulk-update run grepped the mutation response for the field name and reported `failed: 0` for ~5,700 calls when only 6.7%-27% of targets were actually applied.
2. **Absorb the production bot's useful local skill mutations.** A hash diff between `/data/skills/v8-api/` on `v8-admin-assist` and `origin/main` showed 5 files drifted. This PR upstreams the 3 that are operationally useful and were verified in real admin runs.

## Changes

### Opaque-response + bulk-mutation safety (`SKILL.md`, `references/admin-api.md`)

- `SKILL.md`: add `adminControllerAdminUpdateVerse` to the Mutations example block. New "⚠️ Opaque-response mutations" subsection forbidding grep / error-envelope-absence as success signals and mandating re-fetch + field comparison. Generalizes to any admin mutation returning a nullable scalar instead of a structured `{ success, ... }` object.
- `SKILL.md`: new "Bulk mutations (multi-target writes)" section. Required workflow: batch, refresh token at batch boundaries, verify by re-fetch (per call or per-batch sample), report verified-applied (not calls-issued), per-target distribution sanity check after each batch, resume from unverified IDs rather than the full input on retry.
- `references/admin-api.md`: same opaque-response warning attached to `POST /v1/admin/verse/{verseId}`, cross-linked to the SKILL.md sections.

### Bot drift absorption (`SKILL.md`, `queries/*`)

- `queries/verse-list.gql`: new optional `$userUid: String` variable and pass-through; new `userUid` field on each item. Enables "list all verses owned by user X" without per-user fetch — needed for any bulk admin op scoped to a set of accounts.
- `queries/comments-list.gql`: include `createdAt` on comment items so recency-based triage doesn't require a follow-up query per comment.
- `SKILL.md`: document `adminControllerBatchExpireCredits` in the Mutations example block (`userUids` max 1000, response `{success, failed, failedUids, executionTimeMs}`). Update the verse-list row in the Queries table to show the `userUid` filter variable.

## Not included from the bot drift (deliberately)

- `v8-auth.sh` default `V8_API_BASE` change — bot flipped it to the **test** server while its own `SKILL.md` mutation says "always use production". Internally inconsistent; needs a separate reconciliation rather than a piecemeal land.
- `SKILL.md` authentication-line `V8_API_BASE=` prefix and "always use production" callout — same reason; tied to the v8-auth.sh question.
- `references/admin-api.md` Environments reordering — cosmetic only.

## Test plan

- [ ] Skim diff for tone/accuracy.
- [ ] Confirm `adminControllerAdminUpdateVerse` mutation signature matches the current admin schema (verseId + verseUpdateDtoInput).
- [ ] Confirm `adminControllerBatchExpireCredits` signature (input `userUids`, response `{success, failed, failedUids, executionTimeMs}`).
- [ ] Confirm `adminVerseListResponseDto` accepts `userUid` and returns `userUid` on items in current schema.
- [ ] Optional follow-up: add a single-verse admin re-fetch `.gql` to `queries/` so the "verify by re-fetch" pattern has a ready-made query file. Intentionally not in this PR — keep scope to documentation + absorbed drift.

Supersedes #63.

🤖 Generated with [Claude Code](https://claude.com/claude-code)