### PR TITLE
v8-api: absorb production bot's useful skill additions (verse-by-user, comment timestamp, batch-expire-credits)

### DIFF
--- a/packages/v8-api/skills/v8-api/SKILL.md
+++ b/packages/v8-api/skills/v8-api/SKILL.md
@@ -76,7 +76,7 @@ echo "=== Verse ===" ; gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" --queryFi
 | `users-search.gql` | Search users | `{"keyword":"…","limit":20}` |
 | `users-low-balance.gql` | Low balance users | `{"threshold":5,"limit":20}` |
 | `comments-list.gql` | List/search comments | `{"limit":50}` or `{"searchType":"…","keyword":"…","filter":"…"}` |
-| `verse-list.gql` | List verses | `{"limit":20,"featured":"ONLY"}` |
+| `verse-list.gql` | List verses (optionally filter by `userUid`) | `{"limit":20,"featured":"ONLY"}` or `{"userUid":"<uid>","limit":50}` |
 | `game-payments-list.gql` | List game payments | `{"limit":20}` |
 | `game-payment-items-list.gql` | Payment items | `{"gamePaymentId":"<id>","limit":20}` |
 
@@ -93,6 +93,9 @@ gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerCr
 
 # Delete comments
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerBatchCommentAction(batchCommentActionDtoInput: {commentIds: [1,2,3], action: "delete"}) { processed failed errors } }' -l
+
+# Batch expire credits (userUids: max 1000)
+gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerBatchExpireCredits(batchExpireCreditsDtoInput: {userUids: ["<uid1>","<uid2>"]}) { success failed failedUids executionTimeMs } }' -l
 
 # Trigger analytics
 gq $V8_GQL -H "Authorization: Bearer $V8_TOKEN" -q 'mutation { adminControllerTriggerCalculateQualityScores { success executionTimeMs } }' -l

--- a/packages/v8-api/skills/v8-api/queries/comments-list.gql
+++ b/packages/v8-api/skills/v8-api/queries/comments-list.gql
@@ -1,6 +1,6 @@
 query ($limit: Float, $page: Float, $searchType: SearchType, $keyword: String, $filter: Filter) {
   adminCommentsResponseDto(limit: $limit, page: $page, searchType: $searchType, keyword: $keyword, filter: $filter) {
-    comments { id content userDisplayName userEmail verseTitle verseShortId isDeleted likes isReply }
+    comments { id content userDisplayName userEmail verseTitle verseShortId isDeleted likes isReply createdAt }
     total page totalPages
   }
 }

--- a/packages/v8-api/skills/v8-api/queries/verse-list.gql
+++ b/packages/v8-api/skills/v8-api/queries/verse-list.gql
@@ -1,6 +1,6 @@
-query ($limit: Float, $page: Float, $category: String, $featured: Featured, $sortBy: SortBy, $tag: Tag2) {
-  adminVerseListResponseDto(limit: $limit, page: $page, category: $category, featured: $featured, sortBy: $sortBy, tag: $tag) {
-    items { verseId verseShortId title visibility featured showcase createdAt userDisplayName }
+query ($limit: Float, $page: Float, $category: String, $featured: Featured, $sortBy: SortBy, $tag: Tag2, $userUid: String) {
+  adminVerseListResponseDto(limit: $limit, page: $page, category: $category, featured: $featured, sortBy: $sortBy, tag: $tag, userUid: $userUid) {
+    items { verseId verseShortId title visibility featured showcase createdAt userDisplayName userUid }
     total page limit
   }
 }


### PR DESCRIPTION
## Summary

The v8-admin-assist bot has been silently mutating its own copy of the v8-api skill (`/data/skills/v8-api/`) during operation. A hash diff against `origin/main` shows 5 files have drifted. This PR upstreams the 3 changes that are operationally useful and were verified in real admin runs, so the shipped skill stops trailing the bot.

## Changes

**`queries/verse-list.gql`** — add `userUid` filter
- New optional variable `$userUid: String` and pass-through to `adminVerseListResponseDto`.
- New `userUid` field on each item.
- Why: any bulk admin op scoped to a set of accounts ("update every verse owned by users A, B, C") needs this. Without it the bot was doing a separate per-user fetch dance.

**`queries/comments-list.gql`** — include `createdAt`
- Adds `createdAt` to the returned comment shape.
- Why: recency-based triage (spam patterns, recent abuse) is impossible without it short of a follow-up query per comment.

**`SKILL.md`** — document `adminControllerBatchExpireCredits` and the new verse-list variable
- New mutation example in the Mutations block, including the `userUids` (max 1000) shape and the structured `{success, failed, failedUids, executionTimeMs}` response.
- Update the verse-list row in the Queries table to show `userUid` as a filter variable.

## Not included from the bot drift (deliberately)

- `v8-auth.sh` — bot flipped the default `V8_API_BASE` to the **test** server while its own `SKILL.md` mutation says "always use production". Internally inconsistent; needs a separate reconciliation rather than a piecemeal land.
- `SKILL.md` authentication-line `V8_API_BASE=` prefix and "always use production" callout — same reason; tied to the v8-auth.sh question.
- `references/admin-api.md` Environments reordering — cosmetic only.

## Test plan

- [ ] Skim each query change and confirm the new fields/variables exist in the current admin GraphQL schema.
- [ ] Confirm `adminControllerBatchExpireCredits` mutation signature (input shape, response shape) matches the schema.
- [ ] After merge: deploy / re-pull the skill on `v8-admin-assist` so its `/data/skills/v8-api/` no longer drifts on these three files (separate hot-fix track; not in this PR).

Related: #62 (opaque-response mutations / bulk mutation safety docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)